### PR TITLE
fix readme to include code snippet to change directory

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -149,6 +149,12 @@ To create a new application from a basic Python template, run:
 ```
 sunodo create dapp-name --template python
 ```
+
+change directory
+
+```
+cd dapp-name
+```
 ### Building the application
 
 To build an application, run:


### PR DESCRIPTION
change directory step is missing in the readme after Dapp creation
```sunodo create dapp-name --template python
```
  which causes the Dapp building 

```sunodo build
```
to fail.