### PR TITLE
update Sunodo link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to the Cartesi dApp Developer Guide! This comprehensive guide will assis
 
 Currently, two(2) methods exist for creating dApps on Cartesi:
 
-- The first is a [simplified approach](/simplified%20approach/) that uses [Sunodo](docs.sunodo.io), an easy-to-use CLI tool that allows for rapid bootstrapping and building. 
+- The first is a [simplified approach](/simplified%20approach/) that uses [Sunodo](https://docs.sunodo.io), an easy-to-use CLI tool that allows for rapid bootstrapping and building. 
 
 - The second method is the [primitive approach](/primitive%20approach/), which is a more verbose dApp creation process.
 


### PR DESCRIPTION
## Brief
- Fix broken link

## Activities
- Link to Sunodo pointing to a README page instead of a page

## Evidences
![sunodo,error](https://github.com/cartesi/DevGuide/assets/65580797/0ecb2446-a3a7-4737-8929-a99f25edbaef)
